### PR TITLE
fix(document): allow trailing comments

### DIFF
--- a/src/transforms/__snapshots__/document.test.ts.snap
+++ b/src/transforms/__snapshots__/document.test.ts.snap
@@ -888,3 +888,23 @@ documentBody (4:1 ~ 5:1)
   </sequence>
 </documentBody>
 `;
+
+exports[`"---\\nhello\\n... #documentEndComment\\n" 1`] = `
+document (1:1 ~ 3:4)
+1 | ---¶
+  | ^^^^
+2 | hello¶
+  | ^^^^^^
+3 | ...·#documentEndComment¶
+  | ^^^
+4 | ¶
+<document>
+  <trailingComment value="documentEndComment">
+  <documentHead>
+
+  </documentHead>
+  <documentBody>
+    <plain value="hello" />
+  </documentBody>
+</document>
+`;

--- a/src/transforms/document.test.ts
+++ b/src/transforms/document.test.ts
@@ -18,6 +18,7 @@ testCases([
   ["\n%AAA\n---\n123\n\n...\n\n---\n\n456\n\n", selectors],
   ["\n%AAA\n---\n123\n\n...\n\n%BBB\n---\n\n456\n\n", selectors],
   ["- AAA\n# comment\n---\n- BBB", selectors],
+  ["---\nhello\n... #documentEndComment\n", getDocument(0)],
 ]);
 
 function getDocument(documentIndex: number) {

--- a/src/transforms/document.ts
+++ b/src/transforms/document.ts
@@ -1,7 +1,11 @@
 import assert = require("assert");
 import { Context } from "../transform";
 import { Document, DocumentHead, Position } from "../types";
-import { defineCommentParent, getLast } from "../utils";
+import {
+  createCommentAttachableNode,
+  defineCommentParent,
+  getLast,
+} from "../utils";
 
 export function transformDocument(
   document: yaml.Document,
@@ -53,7 +57,7 @@ export function transformDocument(
   })(context.text.slice(0, document.valueRange!.start));
 
   const bodyPosition: Position = (text => {
-    const match = text.match(/^\s*\.\.\.(\s*\n|$)/);
+    const match = text.match(/^\s*\.\.\.(\s*(#[^\n]*)?\n|$)/);
     const marker = "...";
     const markerIndex = match
       ? context.text.indexOf(marker, document.valueRange!.end + match.index!)
@@ -102,5 +106,6 @@ export function transformDocument(
         position: bodyPosition,
       },
     ],
+    ...createCommentAttachableNode(),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,9 +125,13 @@ export interface Root extends Parent {
   comments: Comment[];
 }
 
-export interface Document extends Parent {
+export interface Document extends Parent, CommentAttachable {
   type: "document";
   children: [DocumentHead, DocumentBody];
+  /** always 0 */
+  leadingComments: Comment[];
+  /** only attachable on `...` */
+  trailingComments: Comment[];
 }
 
 export interface DocumentHead extends Parent {
@@ -155,6 +159,8 @@ export interface BlockValue extends Node, Content, CommentAttachable {
   chomping: "clip" | "keep" | "strip";
   indent: null | number;
   value: string;
+  /** always 0 */
+  trailingComments: Comment[];
 }
 
 export interface BlockLiteral extends BlockValue {


### PR DESCRIPTION
```diff
-document (1:1 ~ 4:1)
+document (1:1 ~ 3:4)
 1 | ---¶
   | ^^^^
 2 | hello¶
   | ^^^^^^
 3 | ...·#documentEndComment¶
-  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^
 4 | ¶
-  | ^
 <document>
+  <trailingComment value="documentEndComment">
   <documentHead>
 
   </documentHead>
   <documentBody>
     <plain value="hello" />
-    <comment value="documentEndComment" />
   </documentBody>
 </document>
```